### PR TITLE
테스트 분리(Junit Tag 이용)

### DIFF
--- a/api-user/build.gradle
+++ b/api-user/build.gradle
@@ -14,7 +14,31 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'mysql:mysql-connector-java'
+}
 
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+//전체 테스트
+test {
+    description = 'Runs the total tests.'
+    useJUnitPlatform()
+}
+
+//유닛 테스트
+tasks.register('UnitTest', Test) {
+    group = 'verification'
+    description = 'Runs the Unit tests.'
+    useJUnitPlatform {
+        includeTags 'UnitTest'
+    }
+}
+
+//통합 테스트
+tasks.register('E2eTest', Test) {
+    group = 'verification'
+    description = 'Runs the E2e tests.'
+    useJUnitPlatform {
+        includeTags 'E2eTest'
+    }
 }

--- a/api-user/src/test/java/e2eTest/AuthTest.java
+++ b/api-user/src/test/java/e2eTest/AuthTest.java
@@ -1,0 +1,12 @@
+package e2eTest;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+@Tag("E2eTest")
+public class AuthTest extends BaseE2eTest {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+}

--- a/api-user/src/test/java/e2eTest/BaseE2eTest.java
+++ b/api-user/src/test/java/e2eTest/BaseE2eTest.java
@@ -1,0 +1,37 @@
+package e2eTest;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public class BaseE2eTest {
+    @Container
+    private static MySQLContainer<?> MySQLContainer = new MySQLContainer<>("mysql:8.0");
+
+    @LocalServerPort
+    int port;
+
+    @Bean
+    public TestRestTemplate testRestTemplate() {
+        RestTemplateBuilder builder = new RestTemplateBuilder()
+                .rootUri("http://localhost:" + port);
+        return new TestRestTemplate(builder);
+    }
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.driver-class-name", MySQLContainer::getDriverClassName);
+        registry.add("spring.datasource.jdbc-url", MySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", MySQLContainer::getUsername);
+        registry.add("spring.datasource.password", MySQLContainer::getPassword);
+    }
+}

--- a/api-user/src/test/java/unitTest/AuthUnitTest.java
+++ b/api-user/src/test/java/unitTest/AuthUnitTest.java
@@ -1,0 +1,11 @@
+package unitTest;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+public class AuthUnitTest {
+
+}

--- a/api-user/src/test/resources/application.yml
+++ b/api-user/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
[PR 이슈]
[테스트분리 with Junit Tag](https://github.com/f-lab-edu/retry-lee/issues/18)

[설명]

- 타옵션(gradle sourceSet 설정등) 대비 장점
  - Gradle 설정에 task 추가만 해주면 나머지는 코드레벨에서 확인할 수 있습니다. 그래서 사용하는데에 학습비용이 크지 않습니다.
  - 디렉토리 구조를 변경하지 않고 사용할 수 있어 구조가 다른 옵션에 비해 깔끔합니다.
  - 특정 클래스뿐 아니라 메소드에도 태그를 붙일 수 있어, 보다 유연하게 테스트를 진행할 수 있습니다. (중복 태그 가능)
  - 필요한 테스트만 골라서 실행할 수 있어 불필요한 테스트 실행을 줄일 수 있습니다.