### PR TITLE
로그인 및 토큰 생성 테스트 코드 작성

### DIFF
--- a/api-user/src/main/java/com/user/dto/request/UserRequestDto.java
+++ b/api-user/src/main/java/com/user/dto/request/UserRequestDto.java
@@ -29,8 +29,10 @@ public class UserRequestDto {
     @AllArgsConstructor
     public static class UserSignInReq{
         @NotBlank
+        @Pattern(regexp = "^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식에 맞게 입력하세요.")
         private String email;
         @NotBlank
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[A-Za-z])(?=.*\\W)(?=\\S+$).{8,16}", message = "8 ~ 16자로 입력하세요.")
         private String password;
     }
 }

--- a/api-user/src/main/java/com/user/exception/type/ErrorCode.java
+++ b/api-user/src/main/java/com/user/exception/type/ErrorCode.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
+    ERROR_BE1005("BE1005", "유효하지 않은 토큰입니다."),
+    ERROR_BE1004("BE1004", "사용자를 찾을 수 없습니다."),
+    ERROR_BE1003("BE1003", "로그인 실패, 이메일이나 비밀번호를 확인해주세요."),
     ERROR_BE1002("BE1002", "입력값 검증 실패"),
     ERROR_BE1001("BE1001", "회원가입 실패(이메일 중복), 이메일을 확인해주세요.");
 

--- a/api-user/src/main/java/com/user/utils/jwt/JwtTokenProvider.java
+++ b/api-user/src/main/java/com/user/utils/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.user.utils.jwt;
 
 import com.user.utils.enums.TokenType;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,5 +52,14 @@ public class JwtTokenProvider {
             return bearerToken.substring(6).trim();
         }
         return "";
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
     }
 }

--- a/api-user/src/test/java/com/user/unitTest/service/AuthServiceUnitTest.java
+++ b/api-user/src/test/java/com/user/unitTest/service/AuthServiceUnitTest.java
@@ -114,14 +114,6 @@ public class AuthServiceUnitTest {
         assertNotNull(result);
         assertEquals("accessToken", result.getAccessToken());
         assertEquals("refreshToken", result.getRefreshToken());
-
-        // Verify that findByEmail was called
-        verify(userRepository).findByEmail(req.getEmail());
-        // Verify that passwordEncoder.matches was called
-        verify(passwordEncoder).matches(req.getPassword(), user.getAccount().getPassword());
-        // Verify that jwtTokenProvider.generateToken was called twice (for ACCESS and REFRESH tokens)
-        verify(jwtTokenProvider, times(2)).generateToken(any(TokenType.class), anyLong(), any(Date.class));
-
     }
 
     @Test
@@ -134,9 +126,6 @@ public class AuthServiceUnitTest {
         when(userRepository.findByEmail(req.getEmail())).thenReturn(Optional.empty());
 
         assertThrows(CustomException.class, () -> authService.signIn(req));
-
-        // Verify that findByEmail was called
-        verify(userRepository).findByEmail(req.getEmail());
     }
 
     @Test
@@ -161,9 +150,6 @@ public class AuthServiceUnitTest {
         when(passwordEncoder.matches(req.getPassword(), user.getAccount().getPassword())).thenReturn(false);
 
         assertThrows(CustomException.class, () -> authService.signIn(req));
-
-        verify(userRepository).findByEmail(req.getEmail());
-        verify(passwordEncoder).matches(req.getPassword(), user.getAccount().getPassword());
     }
 
     @Test
@@ -187,11 +173,6 @@ public class AuthServiceUnitTest {
         assertEquals("newAccessToken", response.getAccessToken());
         assertEquals("newRefreshToken", response.getRefreshToken());
         assertEquals("newRefreshToken", user.getRefreshToken());
-
-        verify(jwtTokenProvider).validateToken("validRefreshToken");
-        verify(jwtTokenProvider).getClaim("validRefreshToken", "userId", Long.class);
-        verify(userRepository).findByUserIdAndRefreshToken(1L, "validRefreshToken");
-        verify(jwtTokenProvider, times(2)).generateToken(any(), eq(1L), any(Date.class));
     }
 
     @Test
@@ -205,7 +186,6 @@ public class AuthServiceUnitTest {
         when(jwtTokenProvider.validateToken(expiredRefreshToken)).thenReturn(false);
 
         assertThrows(CustomException.class, () -> authService.getAccessTokenByRefreshToken(req));
-        verify(jwtTokenProvider).validateToken(expiredRefreshToken);
     }
 
     @Test
@@ -221,9 +201,5 @@ public class AuthServiceUnitTest {
         when(userRepository.findByUserIdAndRefreshToken(1L, validRefreshToken)).thenReturn(Optional.empty());
 
         assertThrows(CustomException.class, () -> authService.getAccessTokenByRefreshToken(req));
-
-        verify(jwtTokenProvider).validateToken(validRefreshToken);
-        verify(jwtTokenProvider).getClaim(validRefreshToken, "userId", Long.class);
-        verify(userRepository).findByUserIdAndRefreshToken(1L, validRefreshToken);
     }
 }

--- a/api-user/src/test/java/com/user/unitTest/util/JwtTokenProviderTest.java
+++ b/api-user/src/test/java/com/user/unitTest/util/JwtTokenProviderTest.java
@@ -1,0 +1,104 @@
+package com.user.unitTest.util;
+
+import com.user.utils.enums.TokenType;
+import com.user.utils.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.mock.web.MockHttpServletRequest;
+import java.time.Duration;
+import java.util.Date;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("UnitTest")
+public class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private final String secret = "testSecretKeyWithAtLeast32Characters";
+    private final Duration accessExpire = Duration.ofMinutes(30);
+    private final Duration refreshExpire = Duration.ofDays(14);
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider(secret, accessExpire, refreshExpire);
+    }
+
+    @Test
+    @DisplayName("Successfully generate access token")
+    void generateAccessTokenSuccess() {
+        Long userId = 1L;
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, userId, new Date());
+
+        assertNotNull(token);
+        assertTrue(jwtTokenProvider.validateToken(token));
+        assertEquals(userId, jwtTokenProvider.getClaim(token, "userId", Long.class));
+        assertEquals("ACCESS", jwtTokenProvider.getClaim(token, "sub", String.class));
+    }
+
+    @Test
+    @DisplayName("Successfully validate token")
+    void validateTokenSuccess() {
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, 1L, new Date());
+        assertTrue(jwtTokenProvider.validateToken(token));
+    }
+
+    @Test
+    @DisplayName("Fail to validate expired token")
+    void failValidateByExpiredToken() {
+        Long userId = 1L;
+        Date pastDate = new Date(System.currentTimeMillis() - 1000 * 60 * 60); // 1시간 전
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, userId, pastDate);
+
+        assertFalse(jwtTokenProvider.validateToken(token));
+    }
+
+    @Test
+    @DisplayName("Fail to validate token with invalid signature")
+    void failValidateTokenByInvalidSignature() {
+        String invalidToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInN1YiI6IkFDQ0VTUyIsImlhdCI6MTYxNjIzOTAyMn0.invalid_signature";
+        assertFalse(jwtTokenProvider.validateToken(invalidToken));
+    }
+
+    @Test
+    @DisplayName("Successfully resolve token from HTTP request")
+    void resolveTokenFromRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String token = "validToken";
+        request.addHeader("Authorization", "Bearer " + token);
+
+        String resolvedToken = jwtTokenProvider.resolveToken(request);
+        assertEquals(token, resolvedToken);
+    }
+
+    @Test
+    @DisplayName("Fail to resolve token from request without Bearer prefix")
+    void failResolveTokenByNoBearerPrefix() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "validToken");
+
+        String resolvedToken = jwtTokenProvider.resolveToken(request);
+        assertEquals("", resolvedToken);
+    }
+
+    @Test
+    @DisplayName("Successfully get claim from token")
+    void getClaimFromToken() {
+        Long userId = 1L;
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, userId, new Date());
+
+        Long extractedUserId = jwtTokenProvider.getClaim(token, "userId", Long.class);
+        String tokenType = jwtTokenProvider.getClaim(token, "sub", String.class);
+
+        assertEquals(userId, extractedUserId);
+        assertEquals("ACCESS", tokenType);
+    }
+
+    @Test
+    @DisplayName("Fail to get non-existent claim from token")
+    void failGetClaimFromTokenByNonExistentClaim() {
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, 1L, new Date());
+
+        assertNull(jwtTokenProvider.getClaim(token, "nonExistentClaim", String.class));
+    }
+}


### PR DESCRIPTION
[PR 이슈]
[로그인 API test code 작성](https://github.com/f-lab-edu/retry-lee/issues/10)

[설명]

- 로그인 시에도 이메일 및 패스워드 형식 검증이 필요할 것 같아 UserSignInReq에 패턴 정규식 추가하였습니다.
- 기존 Service 로직에 구현되어 있지 않거나 RuntimeException 부분들 CustomException으로 수정하였습니다.
- Controller Test에서 andDo(print()) 다 제거 하였습니다.
- 저번 멘토링 시간때 말씀주셨던 것 참고해서 JwtTokenProvider 클래스에 대한 Test Code 따로 작성했습니다.
- 로그인 TestCode에서 verify 구문을 사용했다가 지웠습니다.
  - 이유는 when(...).thenReturn(...) 구문을 사용하는데 메소드가 호출되지 않았다면 반환 값도 사용되지 않아서 테스트가 올바르게 이루어지지 않았을 것이라는 생각에 제거하였습니다.
  - verify가 필요한 경우는 반환 값이 없을 때 해당 메소드가 호출되었는지 확인하는 용도로 사용하면 알맞을 것 같다고 생각합니다.