### PR TITLE
[CI 생성] PR 요청전 TestCode 확인

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,47 @@
+name: Java CI For Test with Gradle
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged
+        ports:
+          - 2375:2375
+
+
+    # 위 설정대신 github actions 의 아래 설정을 통해 사용할 수도 있다.
+    # - name: Build and push Docker image
+    #        uses: docker/build-push-action@v2
+    #        with:
+    #          push: true
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: Run Unit Tests
+        run: ./gradlew UnitTest
+
+      - name: Run E2E Tests
+        run: ./gradlew E2eTest
+        env:
+          TESTCONTAINERS_HOST_OVERRIDE: localhost
+          DOCKER_HOST: tcp://localhost:2375

--- a/api-user/src/test/java/com/user/e2eTest/AuthTest.java
+++ b/api-user/src/test/java/com/user/e2eTest/AuthTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
@@ -53,6 +54,12 @@ public class AuthTest extends BaseE2eTest {
                 .grade("Silver")
                 .build();
         userRepository.save(user);
+    }
+
+    @AfterEach
+    void cleanUpDatabase() {
+        userRepository.deleteAll();
+        accountRepository.deleteAll();
     }
 
     @Test
@@ -167,7 +174,7 @@ public class AuthTest extends BaseE2eTest {
     @Test
     @DisplayName("Fail to login with incorrect password")
     public void loginFailWithIncorrectPassword() {
-        UserSignInReq request = new UserSignInReq(EMAIL, "WrongPassword11!!");
+        UserSignInReq request = new UserSignInReq(EMAIL, "WrongPassword11!");
 
         ResponseEntity<String> response = testRestTemplate.postForEntity(
                 "/auth/signIn",

--- a/api-user/src/test/resources/application.yml
+++ b/api-user/src/test/resources/application.yml
@@ -3,10 +3,10 @@ spring:
       name: api-user-test
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: create-drop
     properties:
       hibernate:
+        hbm2ddl:
+          auto: create-only
         format_sql: true
         show_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -1,3 +1,7 @@
+bootJar.enabled = false
+
+jar.enabled = true
+
 dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/storage/src/main/java/com/storage/entity/Account.java
+++ b/storage/src/main/java/com/storage/entity/Account.java
@@ -2,6 +2,7 @@ package com.storage.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Column;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.*;
@@ -15,6 +16,7 @@ public class Account extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long accountId;
+    @Column(unique = true)
     private String email;
     private String password;
 }

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,4 +1,6 @@
+bootJar.enabled = false
 
+jar.enabled = true
 dependencies {
 
 }


### PR DESCRIPTION
[PR 이슈]
[Test CI 생성](https://github.com/f-lab-edu/retry-lee/issues/21)

[설명]
개인 Repository 로 fork 후 테스트 한 다음 PR 요청드립니다.

- 빌드를 위해 라이브러리 모듈인 support, storage 의 `bootjar = false, jar = true`  추가하였습니다.
***
- test의 application.yml 에서 ddl-auto 변경하였습니다.
  - 테스트는 정상 동작 하지만 testcontainer 특성 상 실행할 때마다 컨테이너가 올라 오기 때문에 기존 create-drop을 사용하면 drop table 쿼리가 발생하는데, 이 쿼리 이전에 연관관계를 없애려고 alter table 로 외래키를 먼저 없애는 쿼리가 나가는 것을 확인하였습니다.
  - 따라서 테이블이 기존에 없는 테스트 환경에서는 우선적용 되는 hibernate 의 설정을 변경하여 create-only 로 변경하였습니다.
  - 추가로 단순히 ddl-auto를 update로 변경하여도 동작은 하는데, 추후에 테스트 수가 방대해지면 효율적이지 못할 것으로 판단해 사용하지 않았습니다.
***
- UserEntity의 Email 필드에 `@Column(unique = true)` 와 테스트 코드에 다음과 같이 넣어주었습니다.
```
 @AfterEach
void cleanUpDatabase() {
   userRepository.deleteAll();
   accountRepository.deleteAll();
}
```
_기존 RDS 에 연결하여 사용할 때는 DB 자체에 unique 가 적용되어 있어 신경쓰지 못했는데, E2eTest 한번에 다 돌리니 테스트가 정상 동작 하지 않는 경우가 발생했습니다. (쿼리 결과가 한건만 나와야하는데, 중복되어 여러건 나오는 경우)_
