### PR TITLE
Admin 로그인, 회원가입 추가

### DIFF
--- a/api-user/src/main/java/com/user/config/SecurityConfig.java
+++ b/api-user/src/main/java/com/user/config/SecurityConfig.java
@@ -36,7 +36,9 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/auth/signUp", "/auth/signIn", "/auth/reissueToken").permitAll()
+                        .requestMatchers("/", "/auth/signUp", "/auth/signIn", "/auth/reissueToken", "/auth/me").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/user/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated())
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/api-user/src/main/java/com/user/controller/AuthController.java
+++ b/api-user/src/main/java/com/user/controller/AuthController.java
@@ -5,12 +5,19 @@ import com.user.dto.request.UserRequestDto.UserRegisterReq;
 import com.user.dto.request.UserRequestDto.UserSignInReq;
 import com.user.dto.response.TokenResponseDto;
 import com.user.dto.response.UserResponseDto.SignInRes;
+import com.user.security.CustomUserDetails;
 import com.user.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,5 +42,19 @@ public class AuthController {
     public ResponseEntity<TokenResponseDto> reissueToken(@RequestBody @Valid TokenRequestDto req){
         TokenResponseDto res = authService.getAccessTokenByRefreshToken(req);
         return ResponseEntity.ok(res);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails != null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("email", userDetails.getUsername());
+            response.put("authorities", userDetails.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.toList()));
+            return ResponseEntity.ok(response);
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not authenticated");
+        }
     }
 }

--- a/api-user/src/main/java/com/user/dto/request/UserRequestDto.java
+++ b/api-user/src/main/java/com/user/dto/request/UserRequestDto.java
@@ -2,6 +2,7 @@ package com.user.dto.request;
 
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -23,6 +24,9 @@ public class UserRequestDto {
         @NotBlank
         @Size(min = 2, max = 10, message = "최소 2자, 최대 10자로 생성하세요")
         private String nickname;
+
+        @NotNull
+        private boolean isAdmin;
     }
 
     @Getter

--- a/api-user/src/main/java/com/user/dto/response/UserResponseDto.java
+++ b/api-user/src/main/java/com/user/dto/response/UserResponseDto.java
@@ -12,5 +12,6 @@ public class UserResponseDto {
     public static class SignInRes{
         String accessToken;
         String refreshToken;
+        String userType;
     }
 }

--- a/api-user/src/main/java/com/user/enums/TokenType.java
+++ b/api-user/src/main/java/com/user/enums/TokenType.java
@@ -1,4 +1,4 @@
-package com.user.utils.enums;
+package com.user.enums;
 
 import lombok.Getter;
 

--- a/api-user/src/main/java/com/user/enums/UserType.java
+++ b/api-user/src/main/java/com/user/enums/UserType.java
@@ -1,0 +1,8 @@
+package com.user.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserType {
+    USER, ADMIN
+}

--- a/api-user/src/main/java/com/user/security/CustomUserDetailService.java
+++ b/api-user/src/main/java/com/user/security/CustomUserDetailService.java
@@ -1,6 +1,8 @@
 package com.user.security;
 
+import com.storage.entity.Admin;
 import com.storage.entity.User;
+import com.storage.repository.AdminRepository;
 import com.storage.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,15 +17,36 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailService implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> {
-                    log.warn("User not found with email : {}", email);
-                    return new UsernameNotFoundException("User not found with email : " + email);
-                });
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user != null) {
+            return CustomUserDetails.of(user);
+        }
 
-        return new CustomUserDetails(user);
+        Admin admin = adminRepository.findByEmail(email).orElse(null);
+        if (admin != null) {
+            return CustomUserDetails.of(admin);
+        }
+
+        throw new UsernameNotFoundException("User not found with email: " + email);
+    }
+
+    public String findEmail(String userType, Long id){
+        // user, admin Id 로 account table 과 조인하여 email 찾아오기
+        if(userType.equals("USER")){
+            User user = userRepository.findById(id).orElse(null);
+            if (user != null) {
+                return user.getAccount().getEmail();
+            }
+        }
+
+        if(userType.equals("ADMIN")){
+            return adminRepository.findEmailById(id).orElse(null);
+        }
+
+        return "";
     }
 }

--- a/api-user/src/main/java/com/user/security/CustomUserDetails.java
+++ b/api-user/src/main/java/com/user/security/CustomUserDetails.java
@@ -1,8 +1,12 @@
 package com.user.security;
 
+import com.storage.entity.Account;
+import com.storage.entity.Admin;
 import com.storage.entity.User;
+import com.user.enums.UserType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
@@ -11,29 +15,37 @@ import java.util.Collection;
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-    private final User user;
+    private final Account account;
+    private final UserType userType;
+    private final Long id;
 
-    /**
-     * Admin 에서는 권한 관련해서 생각해야할게 있지만, ( 예를 들어 admin, user 둘다 권한 부여 등 )
-     * user에서는 권한은 user 하나면 되기 때문에 "role_user" 로 고정
-     *
-     * @return
-     */
+    public static CustomUserDetails of(User user) {
+        return new CustomUserDetails(user.getAccount(), UserType.USER, user.getUserId());
+    }
+
+    public static CustomUserDetails of(Admin admin) {
+        return new CustomUserDetails(admin.getAccount(), UserType.ADMIN, admin.getAdminId());
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        Collection<GrantedAuthority> collection = new ArrayList<>();
-        collection.add((GrantedAuthority) () -> "ROLE_USER");
-
-        return collection;
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        if (userType == UserType.ADMIN) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+            authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        } else {
+            authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        }
+        return authorities;
     }
 
     @Override
     public String getPassword() {
-        return user.getAccount().getPassword();
+        return account.getPassword();
     }
 
     @Override
     public String getUsername() {
-        return user.getAccount().getEmail();
+        return account.getEmail();
     }
 }

--- a/api-user/src/main/java/com/user/service/AuthService.java
+++ b/api-user/src/main/java/com/user/service/AuthService.java
@@ -1,8 +1,10 @@
 package com.user.service;
 
 import com.storage.entity.Account;
+import com.storage.entity.Admin;
 import com.storage.entity.User;
 import com.storage.repository.AccountRepository;
+import com.storage.repository.AdminRepository;
 import com.storage.repository.UserRepository;
 import com.user.exception.CustomException;
 import com.user.exception.type.ErrorCode;
@@ -11,7 +13,8 @@ import com.user.dto.request.UserRequestDto;
 import com.user.dto.request.UserRequestDto.UserRegisterReq;
 import com.user.dto.response.TokenResponseDto;
 import com.user.dto.response.UserResponseDto.SignInRes;
-import com.user.utils.enums.TokenType;
+import com.user.enums.TokenType;
+import com.user.enums.UserType;
 import com.user.utils.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +30,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AdminRepository adminRepository;
 
     @Transactional
     public void register(UserRegisterReq request) {
@@ -34,22 +38,31 @@ public class AuthService {
             throw new CustomException(ErrorCode.ERROR_BE1001);
         }
 
-        // Account 엔티티 생성
+        // Account entity
         Account account = Account.builder()
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .build();
 
-        // User 엔티티 생성
-        User user = User.builder()
-                .nickname(request.getNickname())
-                .account(account)
-                .grade("silver")
-                .build();
-
-        // 저장
+        // Account save
         accountRepository.save(account);
-        userRepository.save(user);
+
+        if (request.isAdmin()) {
+            // Admin entity
+            Admin admin = Admin.builder()
+                    .nickname(request.getNickname())
+                    .account(account)
+                    .build();
+            adminRepository.save(admin);
+        } else {
+            // User entity
+            User user = User.builder()
+                    .nickname(request.getNickname())
+                    .account(account)
+                    .grade("silver")
+                    .build();
+            userRepository.save(user);
+        }
     }
 
     /**
@@ -60,21 +73,42 @@ public class AuthService {
      */
     @Transactional
     public SignInRes signIn(UserRequestDto.UserSignInReq req) {
-        User user = userRepository.findByEmail(req.getEmail())
+        Account account = accountRepository.findByEmail(req.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.ERROR_BE1003));
 
-        if(!passwordEncoder.matches(req.getPassword(), user.getAccount().getPassword())){
+        if (!passwordEncoder.matches(req.getPassword(), account.getPassword())) {
             throw new CustomException(ErrorCode.ERROR_BE1003);
         }
-        // 토큰 생성
-        String accessToken = jwtTokenProvider.generateToken(TokenType.ACCESS, user.getUserId(), new Date());
-        String refreshToken = jwtTokenProvider.generateToken(TokenType.REFRESH, user.getUserId(), new Date());
 
-        user.setRefreshToken(refreshToken);
+        UserType userType;
+        Long id;
+
+        if (adminRepository.existsByAccountId(account.getAccountId())) {
+            Admin admin = adminRepository.findByAccountId(account.getAccountId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ERROR_BE1003));
+            userType = UserType.ADMIN;
+            id = admin.getAdminId();
+        } else {
+            User user = userRepository.findByAccountId(account.getAccountId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ERROR_BE1003));
+            userType = UserType.USER;
+            id = user.getUserId();
+        }
+
+        String accessToken = jwtTokenProvider.generateToken(TokenType.ACCESS, userType, id, new Date());
+        String refreshToken = jwtTokenProvider.generateToken(TokenType.REFRESH, userType, id, new Date());
+
+        // Refresh 토큰 저장
+        if (userType == UserType.ADMIN) {
+            adminRepository.findById(id).ifPresent(admin -> admin.setRefreshToken(refreshToken));
+        } else {
+            userRepository.findById(id).ifPresent(user -> user.setRefreshToken(refreshToken));
+        }
 
         return SignInRes.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .userType(userType.name())
                 .build();
     }
 
@@ -89,19 +123,29 @@ public class AuthService {
             throw new CustomException(ErrorCode.ERROR_BE1005);
         }
 
-        Long userId = jwtTokenProvider.getClaim(req.getRefreshToken(), "userId", Long.class);
+        Long id = jwtTokenProvider.getClaim(req.getRefreshToken(), "id", Long.class);
+        UserType userType = jwtTokenProvider.getClaim(req.getRefreshToken(), "userType", UserType.class);
 
-        User user = userRepository.findByUserIdAndRefreshToken(userId, req.getRefreshToken())
-                .orElseThrow(() -> new CustomException(ErrorCode.ERROR_BE1004));
+        String newAccessToken;
+        String newRefreshToken;
 
-        String accessToken = jwtTokenProvider.generateToken(TokenType.ACCESS, user.getUserId(), new Date());
-        String refreshToken = jwtTokenProvider.generateToken(TokenType.REFRESH, user.getUserId(), new Date());
-
-        user.setRefreshToken(refreshToken);
+        if (userType == UserType.ADMIN) {
+            Admin admin = adminRepository.findByAdminIdAndRefreshToken(id, req.getRefreshToken())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ERROR_BE1004));
+            newAccessToken = jwtTokenProvider.generateToken(TokenType.ACCESS, userType, id, new Date());
+            newRefreshToken = jwtTokenProvider.generateToken(TokenType.REFRESH, userType, id, new Date());
+            admin.setRefreshToken(newRefreshToken);
+        } else {
+            User user = userRepository.findByUserIdAndRefreshToken(id, req.getRefreshToken())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ERROR_BE1004));
+            newAccessToken = jwtTokenProvider.generateToken(TokenType.ACCESS, userType, id, new Date());
+            newRefreshToken = jwtTokenProvider.generateToken(TokenType.REFRESH, userType, id, new Date());
+            user.setRefreshToken(newRefreshToken);
+        }
 
         return TokenResponseDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/api-user/src/main/java/com/user/utils/jwt/JwtTokenProvider.java
+++ b/api-user/src/main/java/com/user/utils/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.user.utils.jwt;
 
-import com.user.utils.enums.TokenType;
+import com.user.enums.TokenType;
+import com.user.enums.UserType;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -36,10 +37,11 @@ public class JwtTokenProvider {
                 .get(claimName, requiredType);
     }
 
-    public String generateToken(TokenType tokenType, Long userId, Date currentDate){
+    public String generateToken(TokenType tokenType, UserType userType, Long id, Date currentDate){
         return Jwts.builder()
                 .subject(String.valueOf(tokenType))
-                .claim("userId", userId)
+                .claim("userType", userType)
+                .claim("id", id)
                 .issuedAt(currentDate)
                 .expiration(new Date(currentDate.getTime() + tokenType.getExpiredMs()))
                 .signWith(secretKey)

--- a/api-user/src/test/java/com/user/e2eTest/AuthTest.java
+++ b/api-user/src/test/java/com/user/e2eTest/AuthTest.java
@@ -66,7 +66,7 @@ public class AuthTest extends BaseE2eTest {
     @DisplayName("Successfully register an account")
     public void registerAccount() {
         // Create account registration request data
-        UserRegisterReq request = new UserRegisterReq("testSuccess@test.com", "Testtest11!!","yogurt");
+        UserRegisterReq request = new UserRegisterReq("testSuccess@test.com", "Testtest11!!","yogurt", false);
 
         // Send POST request
         ResponseEntity<String> response = testRestTemplate.postForEntity(
@@ -82,7 +82,7 @@ public class AuthTest extends BaseE2eTest {
     @DisplayName("Fail to register an account with duplicate email")
     public void failRegisterAccountWithDuplicateEmail() {
         // Create account registration request data with existing email
-        UserRegisterReq request = new UserRegisterReq("test@test.com", "Testtest11!!", "yogurt");
+        UserRegisterReq request = new UserRegisterReq("test@test.com", "Testtest11!!", "yogurt", false);
 
         // Send POST request
         ResponseEntity<String> response = testRestTemplate.postForEntity(
@@ -100,7 +100,7 @@ public class AuthTest extends BaseE2eTest {
     @DisplayName("Fail to register an account with invalid email format")
     public void invalidEmailFormat() {
         // Create account registration request data with existing email
-        UserRegisterReq request = new UserRegisterReq("invalidemail", "Testtest11!!", "yogurt");
+        UserRegisterReq request = new UserRegisterReq("invalidemail", "Testtest11!!", "yogurt", false);
         ResponseEntity<String> response = testRestTemplate.postForEntity(
                 "/auth/signUp",
                 request,
@@ -113,7 +113,7 @@ public class AuthTest extends BaseE2eTest {
     @Test
     @DisplayName("Fail to register an account with invalid password format")
     public void invalidPasswordFormat() {
-        UserRegisterReq request = new UserRegisterReq("test@test.com", "weak", "yogurt");
+        UserRegisterReq request = new UserRegisterReq("test@test.com", "weak", "yogurt", false);
         ResponseEntity<String> response = testRestTemplate.postForEntity(
                 "/auth/signUp",
                 request,
@@ -126,7 +126,7 @@ public class AuthTest extends BaseE2eTest {
     @Test
     @DisplayName("Fail to register an account with invalid nickname length")
     public void invalidNicknameLength() {
-        UserRegisterReq request = new UserRegisterReq("test@test.com", "Testtest11!!", "a");
+        UserRegisterReq request = new UserRegisterReq("test@test.com", "Testtest11!!", "a", false);
         ResponseEntity<String> response = testRestTemplate.postForEntity(
                 "/auth/signUp",
                 request,

--- a/api-user/src/test/java/com/user/unitTest/controller/AuthControllerUnitTest.java
+++ b/api-user/src/test/java/com/user/unitTest/controller/AuthControllerUnitTest.java
@@ -52,7 +52,7 @@ public class AuthControllerUnitTest {
     @Test
     @DisplayName("정상적으로 회원가입에 성공한다.")
     void successSignup() throws Exception {
-        UserRegisterReq req = new UserRegisterReq("test@example.com", "Testtest11!!", "yogurt");
+        UserRegisterReq req = new UserRegisterReq("test@example.com", "Testtest11!!", "yogurt", false);
 
         doNothing().when(authService).register(any(UserRegisterReq.class));
 
@@ -65,7 +65,7 @@ public class AuthControllerUnitTest {
     @Test
     @DisplayName("중복된 이메일일 경우 회원가입에 실패한다.")
     void signupWithExistingEmail() throws Exception {
-        UserRegisterReq req = new UserRegisterReq("existing@example.com", "Password123!", "yogurt");
+        UserRegisterReq req = new UserRegisterReq("existing@example.com", "Password123!", "yogurt", false);
 
         doThrow(new CustomException(ErrorCode.ERROR_BE1001)).when(authService).register(any(UserRegisterReq.class));
 
@@ -79,7 +79,7 @@ public class AuthControllerUnitTest {
     @Test
     @DisplayName("이메일의 형식이 올바르지 않은 경우 작성된 메시지가 반환된다.")
     void signupWithInvalidEmail() throws Exception {
-        UserRegisterReq req = new UserRegisterReq("invalidemail", "Password123!", "yogurt");
+        UserRegisterReq req = new UserRegisterReq("invalidemail", "Password123!", "yogurt", false);
 
         mockMvc.perform(post("/auth/signUp")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -91,7 +91,7 @@ public class AuthControllerUnitTest {
     @Test
     @DisplayName("비밀번호의 형식이 올바르지 않은 경우 작성된 메시지가 반환된다.")
      void signupWithInvalidPassword() throws Exception {
-        UserRegisterReq req = new UserRegisterReq("test@example.com", "weak", "yogurt");
+        UserRegisterReq req = new UserRegisterReq("test@example.com", "weak", "yogurt", false);
 
         mockMvc.perform(post("/auth/signUp")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -103,7 +103,7 @@ public class AuthControllerUnitTest {
     @Test
     @DisplayName("닉네임의 글자 길이가 범위에 맞지 않는 경우 작성된 메시지가 반환된다.")
     void signupWithInvalidNickname() throws Exception {
-        UserRegisterReq req = new UserRegisterReq("test@example.com", "Password123!", "a");
+        UserRegisterReq req = new UserRegisterReq("test@example.com", "Password123!", "a", false);
 
         mockMvc.perform(post("/auth/signUp")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -116,7 +116,7 @@ public class AuthControllerUnitTest {
     @DisplayName("Successfully sign in")
     void successSignIn() throws Exception {
         UserSignInReq req = new UserSignInReq("test@example.com", "Password123!");
-        SignInRes res = new SignInRes("accessToken", "refreshToken");
+        SignInRes res = new SignInRes("accessToken", "refreshToken", "USER");
 
         when(authService.signIn(any(UserSignInReq.class))).thenReturn(res);
 

--- a/api-user/src/test/java/com/user/unitTest/service/AuthServiceUnitTest.java
+++ b/api-user/src/test/java/com/user/unitTest/service/AuthServiceUnitTest.java
@@ -11,7 +11,8 @@ import com.user.dto.response.TokenResponseDto;
 import com.user.dto.response.UserResponseDto.SignInRes;
 import com.user.exception.CustomException;
 import com.user.service.AuthService;
-import com.user.utils.enums.TokenType;
+import com.user.enums.TokenType;
+import com.user.enums.UserType;
 import com.user.utils.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -53,7 +54,7 @@ public class AuthServiceUnitTest {
     @DisplayName("Successfully register an account")
     void successRegister() {
         // Given
-        UserRegisterReq request = new UserRegisterReq("test@test.com", "Password1!", "testuser");
+        UserRegisterReq request = new UserRegisterReq("test@test.com", "Password1!", "testuser", false);
 
         // When
         when(accountRepository.existsByEmail(request.getEmail())).thenReturn(false);
@@ -75,7 +76,7 @@ public class AuthServiceUnitTest {
     @DisplayName("Fail to register an account with duplicate email")
     void registerWithExistingEmail() {
         // Given
-        UserRegisterReq request = new UserRegisterReq("existing@test.com", "Password1!", "testuser");
+        UserRegisterReq request = new UserRegisterReq("existing@test.com", "Password1!", "testuser", false);
 
         // When & Then
         when(accountRepository.existsByEmail(request.getEmail())).thenReturn(true);
@@ -105,8 +106,8 @@ public class AuthServiceUnitTest {
         // When
         when(userRepository.findByEmail(req.getEmail())).thenReturn(Optional.of(user));
         when(passwordEncoder.matches(req.getPassword(), user.getAccount().getPassword())).thenReturn(true);
-        when(jwtTokenProvider.generateToken(eq(TokenType.ACCESS), anyLong(), any(Date.class))).thenReturn("accessToken");
-        when(jwtTokenProvider.generateToken(eq(TokenType.REFRESH), anyLong(), any(Date.class))).thenReturn("refreshToken");
+        when(jwtTokenProvider.generateToken(eq(TokenType.ACCESS), UserType.USER, anyLong(), any(Date.class))).thenReturn("accessToken");
+        when(jwtTokenProvider.generateToken(eq(TokenType.REFRESH), UserType.USER, anyLong(), any(Date.class))).thenReturn("refreshToken");
 
         SignInRes result = authService.signIn(req);
 
@@ -163,8 +164,8 @@ public class AuthServiceUnitTest {
         when(jwtTokenProvider.validateToken("validRefreshToken")).thenReturn(true);
         when(jwtTokenProvider.getClaim("validRefreshToken", "userId", Long.class)).thenReturn(1L);
         when(userRepository.findByUserIdAndRefreshToken(1L, "validRefreshToken")).thenReturn(Optional.of(user));
-        when(jwtTokenProvider.generateToken(eq(TokenType.ACCESS), eq(1L), any(Date.class))).thenReturn("newAccessToken");
-        when(jwtTokenProvider.generateToken(eq(TokenType.REFRESH), eq(1L), any(Date.class))).thenReturn("newRefreshToken");
+        when(jwtTokenProvider.generateToken(eq(TokenType.ACCESS), UserType.USER, eq(1L), any(Date.class))).thenReturn("newAccessToken");
+        when(jwtTokenProvider.generateToken(eq(TokenType.REFRESH), UserType.USER, eq(1L), any(Date.class))).thenReturn("newRefreshToken");
 
         TokenResponseDto response = authService.getAccessTokenByRefreshToken(req);
 

--- a/api-user/src/test/java/com/user/unitTest/util/JwtTokenProviderTest.java
+++ b/api-user/src/test/java/com/user/unitTest/util/JwtTokenProviderTest.java
@@ -1,6 +1,7 @@
 package com.user.unitTest.util;
 
-import com.user.utils.enums.TokenType;
+import com.user.enums.TokenType;
+import com.user.enums.UserType;
 import com.user.utils.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -28,7 +29,7 @@ public class JwtTokenProviderTest {
     @DisplayName("Successfully generate access token")
     void generateAccessTokenSuccess() {
         Long userId = 1L;
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, userId, new Date());
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, userId, new Date());
 
         assertNotNull(token);
         assertTrue(jwtTokenProvider.validateToken(token));
@@ -39,7 +40,7 @@ public class JwtTokenProviderTest {
     @Test
     @DisplayName("Successfully validate token")
     void validateTokenSuccess() {
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, 1L, new Date());
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, 1L, new Date());
         assertTrue(jwtTokenProvider.validateToken(token));
     }
 
@@ -48,7 +49,7 @@ public class JwtTokenProviderTest {
     void failValidateByExpiredToken() {
         Long userId = 1L;
         Date pastDate = new Date(System.currentTimeMillis() - 1000 * 60 * 60); // 1시간 전
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, userId, pastDate);
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, userId, pastDate);
 
         assertFalse(jwtTokenProvider.validateToken(token));
     }
@@ -68,6 +69,7 @@ public class JwtTokenProviderTest {
         request.addHeader("Authorization", "Bearer " + token);
 
         String resolvedToken = jwtTokenProvider.resolveToken(request);
+        System.out.println(resolvedToken);
         assertEquals(token, resolvedToken);
     }
 
@@ -85,7 +87,7 @@ public class JwtTokenProviderTest {
     @DisplayName("Successfully get claim from token")
     void getClaimFromToken() {
         Long userId = 1L;
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, userId, new Date());
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, userId, new Date());
 
         Long extractedUserId = jwtTokenProvider.getClaim(token, "userId", Long.class);
         String tokenType = jwtTokenProvider.getClaim(token, "sub", String.class);
@@ -97,7 +99,7 @@ public class JwtTokenProviderTest {
     @Test
     @DisplayName("Fail to get non-existent claim from token")
     void failGetClaimFromTokenByNonExistentClaim() {
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, 1L, new Date());
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER,1L, new Date());
 
         assertNull(jwtTokenProvider.getClaim(token, "nonExistentClaim", String.class));
     }

--- a/api-user/src/test/java/com/user/unitTest/util/JwtTokenProviderTest.java
+++ b/api-user/src/test/java/com/user/unitTest/util/JwtTokenProviderTest.java
@@ -28,12 +28,14 @@ public class JwtTokenProviderTest {
     @Test
     @DisplayName("Successfully generate access token")
     void generateAccessTokenSuccess() {
-        Long userId = 1L;
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, userId, new Date());
+        Long id = 1L;
+        String userType = "USER";
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, id, new Date());
 
         assertNotNull(token);
         assertTrue(jwtTokenProvider.validateToken(token));
-        assertEquals(userId, jwtTokenProvider.getClaim(token, "userId", Long.class));
+        assertEquals(id, jwtTokenProvider.getClaim(token, "id", Long.class));
+        assertEquals(userType, jwtTokenProvider.getClaim(token, "userType", String.class));
         assertEquals("ACCESS", jwtTokenProvider.getClaim(token, "sub", String.class));
     }
 
@@ -86,13 +88,16 @@ public class JwtTokenProviderTest {
     @Test
     @DisplayName("Successfully get claim from token")
     void getClaimFromToken() {
-        Long userId = 1L;
-        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, userId, new Date());
+        Long id = 1L;
+        String userType = "USER";
+        String token = jwtTokenProvider.generateToken(TokenType.ACCESS, UserType.USER, id, new Date());
 
-        Long extractedUserId = jwtTokenProvider.getClaim(token, "userId", Long.class);
+        Long extractedUserId = jwtTokenProvider.getClaim(token, "id", Long.class);
+        String extractedUserType = jwtTokenProvider.getClaim(token, "userType", String.class);
         String tokenType = jwtTokenProvider.getClaim(token, "sub", String.class);
 
-        assertEquals(userId, extractedUserId);
+        assertEquals(id, extractedUserId);
+        assertEquals(userType, extractedUserType);
         assertEquals("ACCESS", tokenType);
     }
 

--- a/storage/src/main/java/com/storage/entity/Admin.java
+++ b/storage/src/main/java/com/storage/entity/Admin.java
@@ -1,0 +1,23 @@
+package com.storage.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Admin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long adminId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+    private String nickname;
+    private String refreshToken;
+}

--- a/storage/src/main/java/com/storage/repository/AccountRepository.java
+++ b/storage/src/main/java/com/storage/repository/AccountRepository.java
@@ -3,7 +3,10 @@ package com.storage.repository;
 import com.storage.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
     boolean existsByEmail(String email);
+    Optional<Account> findByEmail(String email);
 }

--- a/storage/src/main/java/com/storage/repository/AdminRepository.java
+++ b/storage/src/main/java/com/storage/repository/AdminRepository.java
@@ -1,0 +1,30 @@
+package com.storage.repository;
+
+import com.storage.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    @Query("select count(a) > 0" +
+            " from Admin a" +
+            " join a.account ac" +
+            " where ac.accountId = :accountId")
+    boolean existsByAccountId(Long accountId);
+
+    @Query("select a from Admin a" +
+            " join fetch a.account ac" +
+            " where ac.accountId = :accountId")
+    Optional<Admin> findByAccountId(Long accountId);
+
+    Optional<Admin> findByAdminIdAndRefreshToken(Long id, String refreshToken);
+
+    @Query("select a from Admin a" +
+            " join fetch a.account ac" +
+            " where ac.email = :email")
+    Optional<Admin> findByEmail(String email);
+
+    @Query("SELECT a.account.email FROM Admin a WHERE a.adminId = :id")
+    Optional<String> findEmailById(Long id);
+}

--- a/storage/src/main/java/com/storage/repository/UserRepository.java
+++ b/storage/src/main/java/com/storage/repository/UserRepository.java
@@ -14,4 +14,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByUserIdAndRefreshToken(Long id, String refreshToken);
+
+    @Query("select u from User u" +
+            " join fetch u.account a" +
+            " where a.accountId = :accountId")
+    Optional<User> findByAccountId(Long accountId);
+
 }


### PR DESCRIPTION
[PR 이슈]
[Admin 회원가입, 로그인](https://github.com/f-lab-edu/retry-lee/issues/27)

[설명]

### 1. Security Config
- endpoint에 따라 권한 추가하였습니다. (현재는 /admin, /user 로 되어 있지만 호텔 등록, 예약 별로 수정 예정)

### 2. UserType Enum 추가
- USER, ADMIN

### 3. Jwt Token 생성 메소드 수정
- claim에 userId 가 아닌 id 로 변경하였습니다.
- claim에 userType 추가하였습니다.
  - Token Filter에서 user인지 admin 인지 확인하기 위해 추가하였습니다.

### 4. CustomUserDetails 수정
- userType 에 따라 권한부여 하였습니다.
  - admin일 경우 user, admin 둘 다 부여.

### 5. Jwt Filter 수정
- loadUserByUsername 메소드를 사용하는데, claim에서는 email 정보를 가져올 수 없어 id와 userType으로 email을 얻어올 수 있도록 구현했습니다.

### 6. AuthService 수정
- userType 이 admin, user 로 나뉘어지는 관계로 요청 값(isAdmin)을 추가해 조건문으로 처리하였습니다.

***

수정을 전체적으로 다 한 후 권한이 제대로 적용되었는지 직접 보고 싶어 로컬에서 로그인 진행 후 accessToken을 헤더값에 추가하여 테스트를 아래와 같은 코드로 진행하고 의도한 대로 권한 값이 리턴되는 것을 확인하였습니다.

```
@GetMapping("/me")
    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
        if (userDetails != null) {
            Map<String, Object> response = new HashMap<>();
            response.put("email", userDetails.getUsername());
            response.put("authorities", userDetails.getAuthorities().stream()
                    .map(GrantedAuthority::getAuthority)
                    .collect(Collectors.toList()));
            return ResponseEntity.ok(response);
        } else {
            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not authenticated");
        }
    }
```